### PR TITLE
Remove duplicate ligne

### DIFF
--- a/tirtos/packages/ti/net/wolfssl/package.bld
+++ b/tirtos/packages/ti/net/wolfssl/package.bld
@@ -45,7 +45,6 @@ var wolfSSLObjList = [
     "wolfcrypt/src/wc_port.c",
     "wolfcrypt/src/wolfmath.c",
     "wolfcrypt/src/wc_encrypt.c",
-    "wolfcrypt/src/kdf.c",
 
     "src/internal.c",
     "src/wolfio.c",


### PR DESCRIPTION
This duplicate ligne cause a build fail

# Description

This duplicate ligne make a error when build for TI target
```
making package.mak (because of package.bld) ...
js: "./package.bld", line 60: Error: addObjects was passed 'wolfcrypt/src/kdf.c' more than once for the library 'lib/wolfssl'
gmake[1]: *** Deleting file 'package.mak'
```

Fixes zd#

# Testing

Now it build.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
